### PR TITLE
Support only Python 3

### DIFF
--- a/MathsCamp.R
+++ b/MathsCamp.R
@@ -194,12 +194,13 @@ system2Args <- list(
 #' For details please refer to system2 documentation on
 #' stdout arg
 #'
-#' @param s Boolean indicating whether stdout is TRUE or FALSE
+#' @param s Boolean indicating whether stdout is TRUE or FALSE. Default to TRUE
 #' @return Partial function of system2 with stdout provided
-#' @examples:
+#' @examples
+#' system2WithStdout() -> <partialized> system2(stdout = TRUE, ...)
 #' system2WithStdout(TRUE) -> <partialized> system2(stdout = TRUE, ...)
 #' system2WithStdout(FALSE) -> <partialized> system2(stdout = FALSE, ...)
-system2WithStdout <- function(s) partial(system2, stdout = s)
+system2WithStdout <- function(s = TRUE) partial(system2, stdout = s)
 
 # partial function of do.call with "what" arg set to system2
 do.call.system2 <- partial(do.call, what = system2WithStdout(FALSE))
@@ -207,7 +208,7 @@ do.call.system2 <- partial(do.call, what = system2WithStdout(FALSE))
 #' Get a list of exit code of python command specified in system2Args
 #'
 #' @return A list of python command exit codes
-#' @examples:
+#' @examples
 #' getPythonExitCodes() -> list("command1" = 0, "command2" = 1)
 getPythonExitCodes <- function() lapply(system2Args, do.call.system2)
 
@@ -232,7 +233,7 @@ isPython3 <- function() {
   if (length(zeroExitCode) == 0) return(FALSE)
 
   successCommand <- names(zeroExitCode)[1]
-  stdout <- do.call(system2WithStdout(TRUE), system2Args[[successCommand]]) 
+  stdout <- do.call(system2WithStdout(), system2Args[[successCommand]]) 
 
   pythonVersion <- stdout %>% str_extract("\\d\\.\\d") %>% as.numeric
 

--- a/MathsCamp.R
+++ b/MathsCamp.R
@@ -176,27 +176,78 @@ if (saveLocal) {
 # --------- system call to tidy up widgets --------- #
 # -------------------------------------------------- #
 
-#' Check if Python executable exists on client's machine. Preferred Python 3
-#' 
-#' return Boolean indicating whether Python exists
-#' Examples:
-#' isPythonExists() -> return TRUE if exists
-isPythonExists <- function() {
-  # check for a more specific python3 command first,
-  # then chech for a more generic python command
-  exitCode3 <- system("python3 --version")
-  exitCode <- system("python --version")
+# check for both "python3" and "python" commands
+# since some system will use "python3" as Python 3 command
+# Note: sometimes "python" is used to represent Python 2,
+#       this is true in some system that consists of both
+#       Python 2 and Python 3. Therefore, an additional
+#       check is needed for "python" command
+system2Args <- list(
+  python3 = list(command = "python3", args = "--version"),
+  python =  list(command = "python", args = "--version")
+)
 
-  return(exitCode3 == 0 | exitCode == 0)
+#' Produce partial function of system2 with stdout arg.
+#' system2 with stdout = TRUE will capture the output
+#' and return it as character vector.
+#' 
+#' For details please refer to system2 documentation on
+#' stdout arg
+#'
+#' @param s Boolean indicating whether stdout is TRUE or FALSE
+#' @return Partial function of system2 with stdout provided
+#' @examples:
+#' system2WithStdout(TRUE) -> <partialized> system2(stdout = TRUE, ...)
+#' system2WithStdout(FALSE) -> <partialized> system2(stdout = FALSE, ...)
+system2WithStdout <- function(s) partial(system2, stdout = s)
+
+# partial function of do.call with "what" arg set to system2
+do.call.system2 <- partial(do.call, what = system2WithStdout(FALSE))
+
+#' Get a list of exit code of python command specified in system2Args
+#'
+#' @return A list of python command exit codes
+#' @examples:
+#' getPythonExitCodes() -> list("command1" = 0, "command2" = 1)
+getPythonExitCodes <- function() lapply(system2Args, do.call.system2)
+
+#' Check if Python executable exists on client's machine and is on PATH.
+#' 
+#' @return Boolean indicating whether Python exists
+#' @examples
+#' isPythonExists() -> TRUE (if exists)
+isPythonExists <- function() 0 %in% getPythonExitCodes()
+
+#' Check if Python version is 3 and above
+#' 
+#' @return Boolean indicating whether Python version is 3 and above
+#' @examples
+#' isPython3() -> TRUE (if python --version > 3)
+isPython3 <- function() {
+  zeroExitCode <- getPythonExitCodes() %>% Filter(function(x) x == 0, .)
+
+  # Sanity check for zeroExitCode to have contents
+  # As a precautionary step if client does not call
+  # isPythonExists prior to this func
+  if (length(zeroExitCode) == 0) return(FALSE)
+
+  successCommand <- names(zeroExitCode)[1]
+  stdout <- do.call(system2WithStdout(TRUE), system2Args[[successCommand]]) 
+
+  pythonVersion <- stdout %>% str_extract("\\d\\.\\d") %>% as.numeric
+
+  return(pythonVersion > 3)
 }
 
 # if Python exists in client's compueter, update widget files
 # and delete their corresponding folders
 if (!isPythonExists()) {
   stop("Sorry, Python is not found in your environment variables. Please check it for further execution...")
+} else if (isPythonExists() && !isPython3()) {
+  stop("Seems like you are not using Python 3. Please install it for futher execution...")
 } else {
   print("Python is found on your machine. Starting to tidy up widgets now...")
-  system("python ./tidyWidgets.py")
+  system2("python",  "./tidyWidgets.py")
 }
 # -------------------------------------------------- #
 # --------- system call to tidy up widgets --------- #


### PR DESCRIPTION
Support only `Python` with version `3` and above, or more specifically, version `3.5` and above, in accordance to `mypy` and `typing` support.

For another reason, `Python 2` is going to be unsupported and reach end of life on January 1st, 2020. There should be no reason to support for `Python 2.7` anymore.

**Additional changes in `R`**:
- Update `system` to `system2` for OS command execution in `R`